### PR TITLE
Fixes extraction of tagged_lemma for syntactical alignment

### DIFF
--- a/align/calculate_alignment.py
+++ b/align/calculate_alignment.py
@@ -508,7 +508,7 @@ def ConvoByConvoAnalysis(dataframe,
     tok1 = [word for turn in df_A['token'] for word in turn]
     lem1 = [word for turn in df_A['lemma'] for word in turn]
     penn_tok1 = [POS for turn in df_A['tagged_token'] for POS in turn]
-    penn_lem1 = [POS for turn in df_A['tagged_token'] for POS in turn]
+    penn_lem1 = [POS for turn in df_A['tagged_lemma'] for POS in turn]
     if add_stanford_tags:
 
         if isinstance(df_A['tagged_stan_token'][0], list):
@@ -527,7 +527,7 @@ def ConvoByConvoAnalysis(dataframe,
     tok2 = [word for turn in df_B['token'] for word in turn]
     lem2 = [word for turn in df_B['lemma'] for word in turn]
     penn_tok2 = [POS for turn in df_B['tagged_token'] for POS in turn]
-    penn_lem2 = [POS for turn in df_B['tagged_token'] for POS in turn]
+    penn_lem2 = [POS for turn in df_B['tagged_lemma'] for POS in turn]
     if add_stanford_tags:
 
         if isinstance(df_A['tagged_stan_token'][0],list):


### PR DESCRIPTION
The convo alignment scores for syntax_penn_tok2 and syntax_penn_lem2 were identical because the tagged_token were used for both.

Identical scores (col 1 and 2):
<img width="650" alt="identical_tok_and_lem_syntax_alignments" src="https://user-images.githubusercontent.com/22819047/66121711-1b98a600-e5de-11e9-8d1c-0a41b299935c.png">

We used the following prepared file to check that the scores were identical when they shouldn't be. Note that the token tags have been manually replaced so they are different from the lemma tags. Perhaps useful for a unit test?
[time191-cond1.txt](https://github.com/nickduran/align-linguistic-alignment/files/3685715/time191-cond1.txt)

Note: We haven't tested the fix, but it seems very straight forward.